### PR TITLE
feat(inputs): remove HipChat input to bot

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/divisionone/go-bot/command"
 	"github.com/divisionone/go-bot/input"
-	_ "github.com/divisionone/go-bot/input/hipchat"
 	_ "github.com/divisionone/go-bot/input/slack"
 	botc "github.com/divisionone/micro/internal/command/bot"
 	"github.com/micro/go-log"


### PR DESCRIPTION
HipChat input depends on https://github.com/micro/hipchat, a repository which has been removed by the maintainer. As we do not intend to use HipChat integration here, we can safely remove this dependency/feature.